### PR TITLE
Replace IOSDriver with WindowsDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To test a UWP app, you can use any Selenium supported language and simply specif
 // Launch the AlarmClock app
 DesiredCapabilities appCapabilities = new DesiredCapabilities();
 appCapabilities.SetCapability("app", "Microsoft.WindowsAlarms_8wekyb3d8bbwe!App");
-AlarmClockSession = new IOSDriver<IOSElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
+AlarmClockSession = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
 
 // Control the AlarmClock app
 AlarmClockSession.FindElementByAccessibilityId("AddAlarmButton").Click();
@@ -142,7 +142,7 @@ To test a classic Windows app, you can also use any Selenium supported language 
 // Launch Notepad
 DesiredCapabilities appCapabilities = new DesiredCapabilities();
 appCapabilities.SetCapability("app", @"C:\Windows\System32\notepad.exe");
-NotepadSession = new IOSDriver<IOSElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
+NotepadSession = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
 
 // Control the Notepad app
 NotepadSession.FindElementByClassName("Edit").SendKeys("This is some text");

--- a/Samples/C#/AlarmClockTest/AlarmClockTest.csproj
+++ b/Samples/C#/AlarmClockTest/AlarmClockTest.csproj
@@ -35,26 +35,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver, Version=1.5.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Appium.WebDriver.1.5.0.1\lib\net40\appium-dotnet-driver.dll</HintPath>
+    <Reference Include="appium-dotnet-driver, Version=3.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Appium.WebDriver.3.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.WebDriver.2.48.2\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.Support.2.48.2\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Samples/C#/AlarmClockTest/Scenario.cs
+++ b/Samples/C#/AlarmClockTest/Scenario.cs
@@ -18,7 +18,7 @@ using System;
 using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium;
-using OpenQA.Selenium.Appium.iOS; // Temporary placeholder until Windows namespace exists
+using OpenQA.Selenium.Appium.Windows; // Temporary placeholder until Windows namespace exists
 using OpenQA.Selenium.Remote;
 
 namespace AlarmClockTest
@@ -27,8 +27,8 @@ namespace AlarmClockTest
     public class Scenario
     {
         protected const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
-        protected static IOSDriver<IOSElement> AlarmClockSession;   // Temporary placeholder until Windows namespace exists
-        protected static IOSDriver<IOSElement> DesktopSession;      // Temporary placeholder until Windows namespace exists
+        protected static WindowsDriver<WindowsElement> AlarmClockSession;   // Temporary placeholder until Windows namespace exists
+        protected static WindowsDriver<WindowsElement> DesktopSession;      // Temporary placeholder until Windows namespace exists
         private const string NewAlarmName = "Windows Application Driver Test Alarm";
 
         [ClassInitialize]
@@ -37,14 +37,14 @@ namespace AlarmClockTest
             // Launch the AlarmClock app
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "Microsoft.WindowsAlarms_8wekyb3d8bbwe!App");
-            AlarmClockSession = new IOSDriver<IOSElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+            AlarmClockSession = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(AlarmClockSession);
             AlarmClockSession.Manage().Timeouts().ImplicitlyWait(TimeSpan.FromSeconds(2));
 
             // Create a session for Desktop
             DesiredCapabilities desktopCapabilities = new DesiredCapabilities();
             desktopCapabilities.SetCapability("app", "Root");
-            DesktopSession = new IOSDriver<IOSElement>(new Uri(WindowsApplicationDriverUrl), desktopCapabilities);
+            DesktopSession = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), desktopCapabilities);
             Assert.IsNotNull(DesktopSession);
 
             // Ensure app is started in the default main page

--- a/Samples/C#/AlarmClockTest/Scenario.cs
+++ b/Samples/C#/AlarmClockTest/Scenario.cs
@@ -18,7 +18,7 @@ using System;
 using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium;
-using OpenQA.Selenium.Appium.Windows; // Temporary placeholder until Windows namespace exists
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace AlarmClockTest
@@ -27,8 +27,8 @@ namespace AlarmClockTest
     public class Scenario
     {
         protected const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
-        protected static WindowsDriver<WindowsElement> AlarmClockSession;   // Temporary placeholder until Windows namespace exists
-        protected static WindowsDriver<WindowsElement> DesktopSession;      // Temporary placeholder until Windows namespace exists
+        protected static WindowsDriver<WindowsElement> AlarmClockSession;
+        protected static WindowsDriver<WindowsElement> DesktopSession;
         private const string NewAlarmName = "Windows Application Driver Test Alarm";
 
         [ClassInitialize]

--- a/Samples/C#/AlarmClockTest/packages.config
+++ b/Samples/C#/AlarmClockTest/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="1.5.0.1" targetFramework="net45" />
+  <package id="Appium.WebDriver" version="3.0.0.1" targetFramework="net45" />
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Selenium.Support" version="2.48.2" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.48.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/Samples/C#/CortanaTest/CortanaTest.csproj
+++ b/Samples/C#/CortanaTest/CortanaTest.csproj
@@ -35,26 +35,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver, Version=1.5.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Appium.WebDriver.1.5.0.1\lib\net40\appium-dotnet-driver.dll</HintPath>
+    <Reference Include="appium-dotnet-driver, Version=3.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Appium.WebDriver.3.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.WebDriver.2.48.2\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.48.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.Support.2.48.2\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Samples/C#/CortanaTest/Scenario.cs
+++ b/Samples/C#/CortanaTest/Scenario.cs
@@ -17,7 +17,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium;
-using OpenQA.Selenium.Appium.Windows; // Temporary placeholder until Windows namespace exists
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace CortanaTest
@@ -26,8 +26,8 @@ namespace CortanaTest
     public class Scenario
     {
         protected const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
-        protected static WindowsDriver<WindowsElement> CortanaSession;      // Temporary placeholder until Windows namespace exists
-        protected static WindowsDriver<WindowsElement> DesktopSession;      // Temporary placeholder until Windows namespace exists
+        protected static WindowsDriver<WindowsElement> CortanaSession;
+        protected static WindowsDriver<WindowsElement> DesktopSession;
         protected static AppiumWebElement CortanaButton;
 
         [ClassInitialize]

--- a/Samples/C#/CortanaTest/Scenario.cs
+++ b/Samples/C#/CortanaTest/Scenario.cs
@@ -17,7 +17,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium;
-using OpenQA.Selenium.Appium.iOS; // Temporary placeholder until Windows namespace exists
+using OpenQA.Selenium.Appium.Windows; // Temporary placeholder until Windows namespace exists
 using OpenQA.Selenium.Remote;
 
 namespace CortanaTest
@@ -26,8 +26,8 @@ namespace CortanaTest
     public class Scenario
     {
         protected const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
-        protected static IOSDriver<IOSElement> CortanaSession;      // Temporary placeholder until Windows namespace exists
-        protected static IOSDriver<IOSElement> DesktopSession;      // Temporary placeholder until Windows namespace exists
+        protected static WindowsDriver<WindowsElement> CortanaSession;      // Temporary placeholder until Windows namespace exists
+        protected static WindowsDriver<WindowsElement> DesktopSession;      // Temporary placeholder until Windows namespace exists
         protected static AppiumWebElement CortanaButton;
 
         [ClassInitialize]
@@ -36,7 +36,7 @@ namespace CortanaTest
             // Create a session for Desktop
             DesiredCapabilities desktopCapabilities = new DesiredCapabilities();
             desktopCapabilities.SetCapability("app", "Root");
-            DesktopSession = new IOSDriver<IOSElement>(new Uri(WindowsApplicationDriverUrl), desktopCapabilities);
+            DesktopSession = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), desktopCapabilities);
             Assert.IsNotNull(DesktopSession);
 
             // Launch Cortana Window to allow session creation to find it
@@ -47,7 +47,7 @@ namespace CortanaTest
             // Create session for already running Cortana
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "Microsoft.Windows.Cortana_cw5n1h2txyewy!CortanaUI");
-            CortanaSession = new IOSDriver<IOSElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+            CortanaSession = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(CortanaSession);
             CortanaSession.Manage().Timeouts().ImplicitlyWait(TimeSpan.FromSeconds(2));
         }

--- a/Samples/C#/CortanaTest/packages.config
+++ b/Samples/C#/CortanaTest/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="1.5.0.1" targetFramework="net45" />
+  <package id="Appium.WebDriver" version="3.0.0.1" targetFramework="net45" />
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Selenium.Support" version="2.48.2" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.48.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/Samples/C#/NotepadTest/AdvancedScenario.cs
+++ b/Samples/C#/NotepadTest/AdvancedScenario.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using System.Collections.Generic;
 
 namespace NotepadTest
@@ -16,7 +16,7 @@ namespace NotepadTest
         protected const string TargetSaveLocation = @"%TEMP%\";
 
 
-        protected static IOSDriver<IOSElement> NotepadSession;
+        protected static WindowsDriver<WindowsElement> NotepadSession;
 
         [ClassInitialize]
         public static void Setup(TestContext context)
@@ -24,7 +24,7 @@ namespace NotepadTest
             // Launch Notepad Classic Windows Application
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", NotepadAppId);
-            NotepadSession = new IOSDriver<IOSElement>(new Uri(AppDriverUrl), appCapabilities);
+            NotepadSession = new WindowsDriver<WindowsElement>(new Uri(AppDriverUrl), appCapabilities);
             Assert.IsNotNull(NotepadSession);
             // Verify that Notepad is started with untitled new file
             Assert.AreEqual("Untitled - Notepad", NotepadSession.Title);
@@ -156,13 +156,13 @@ namespace NotepadTest
             // Launch Windows Explorer to delete the saved text file above
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", ExplorerAppId);
-            IOSDriver<IOSElement> WindowsExplorerSession = new IOSDriver<IOSElement>(new Uri(AppDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> WindowsExplorerSession = new WindowsDriver<WindowsElement>(new Uri(AppDriverUrl), appCapabilities);
             Assert.IsNotNull(WindowsExplorerSession);
 
             // Create Desktop session to control context menu and access dialogs
             DesiredCapabilities desktopCapabilities = new DesiredCapabilities();
             desktopCapabilities.SetCapability("app", "Root");
-            IOSDriver<IOSElement> DesktopSession = new IOSDriver<IOSElement>(new Uri(AppDriverUrl), desktopCapabilities);
+            WindowsDriver<WindowsElement> DesktopSession = new WindowsDriver<WindowsElement>(new Uri(AppDriverUrl), desktopCapabilities);
             Assert.IsNotNull(DesktopSession);
 
             // Navigate Windows Explorer to the target save location folder

--- a/Samples/C#/NotepadTest/NotepadTest.csproj
+++ b/Samples/C#/NotepadTest/NotepadTest.csproj
@@ -35,8 +35,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver">
-      <HintPath>packages\Appium.WebDriver.2.0.1.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+    <Reference Include="appium-dotnet-driver, Version=3.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Appium.WebDriver.3.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core">
       <HintPath>packages\Castle.Core.4.0.0-beta002\lib\net45\Castle.Core.dll</HintPath>
@@ -52,11 +53,13 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver">
-      <HintPath>packages\Selenium.WebDriver.3.0.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support">
-      <HintPath>packages\Selenium.Support.3.0.0\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -73,6 +76,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Choose>

--- a/Samples/C#/NotepadTest/Scenario.cs
+++ b/Samples/C#/NotepadTest/Scenario.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace NotepadTest
 {
@@ -15,7 +15,7 @@ namespace NotepadTest
         protected const string ExplorerAppId = @"C:\Windows\System32\explorer.exe";
         protected const string TestFileName = "NotepadTestOutputFile.txt";
         protected const string TargetSaveLocation = @"%TEMP%\";
-        protected static IOSDriver<IOSElement> NotepadSession;
+        protected static WindowsDriver<WindowsElement> NotepadSession;
 
         [ClassInitialize]
         public static void Setup(TestContext context)
@@ -23,7 +23,7 @@ namespace NotepadTest
             // Launch Notepad Classic Windows Application
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", NotepadAppId);
-            NotepadSession = new IOSDriver<IOSElement>(new Uri(AppDriverUrl), appCapabilities);
+            NotepadSession = new WindowsDriver<WindowsElement>(new Uri(AppDriverUrl), appCapabilities);
             Assert.IsNotNull(NotepadSession);
         }
 
@@ -84,13 +84,13 @@ namespace NotepadTest
             // Launch Windows Explorer to delete the saved text file above
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", ExplorerAppId);
-            IOSDriver<IOSElement> WindowsExplorerSession = new IOSDriver<IOSElement>(new Uri(AppDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> WindowsExplorerSession = new WindowsDriver<WindowsElement>(new Uri(AppDriverUrl), appCapabilities);
             Assert.IsNotNull(WindowsExplorerSession);
 
             // Create Desktop session to control context menu and access dialogs
             DesiredCapabilities desktopCapabilities = new DesiredCapabilities();
             desktopCapabilities.SetCapability("app", "Root");
-            IOSDriver<IOSElement> DesktopSession = new IOSDriver<IOSElement>(new Uri(AppDriverUrl), desktopCapabilities);
+            WindowsDriver<WindowsElement> DesktopSession = new WindowsDriver<WindowsElement>(new Uri(AppDriverUrl), desktopCapabilities);
             Assert.IsNotNull(DesktopSession);
 
             // Navigate Windows Explorer to the target save location folder

--- a/Samples/C#/NotepadTest/app.config
+++ b/Samples/C#/NotepadTest/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Samples/C#/NotepadTest/packages.config
+++ b/Samples/C#/NotepadTest/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="2.0.1.1" targetFramework="net45" />
+  <package id="Appium.WebDriver" version="3.0.0.1" targetFramework="net45" />
   <package id="Castle.Core" version="4.0.0-beta002" targetFramework="net45" />
   <package id="MSTest.TestAdapter" version="1.1.5-preview" targetFramework="net45" />
   <package id="MSTest.TestFramework" version="1.0.6-preview" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.2-beta1" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.0.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="3.0.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/Samples/C#/WPFNotepadTest/WPFNotepadTest/Scenario.cs
+++ b/Samples/C#/WPFNotepadTest/WPFNotepadTest/Scenario.cs
@@ -1,6 +1,6 @@
 using System;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace WPFNotepadTest
@@ -12,7 +12,7 @@ namespace WPFNotepadTest
         protected const string WpfNotepadAppId = @"C:\dev\wpfnotepad.exe"; //copy and build binary from source https://codeoverload.wordpress.com/2010/05/01/wpf-notepad/   
         protected const string ExplorerAppId = @"wpfnotepad.exe";
         protected const string TargetSaveLocation = @"%TEMP%\";
-        protected static IOSDriver<IOSElement> WpfnotepadSession;
+        protected static WindowsDriver<WindowsElement> WpfnotepadSession;
 
         [ClassInitialize]
         public static void Setup(TestContext context)
@@ -20,7 +20,7 @@ namespace WPFNotepadTest
             // Launch Word Classic Windows Application
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", WpfNotepadAppId);
-            WpfnotepadSession = new IOSDriver<IOSElement>(new Uri(AppDriverUrl), appCapabilities);
+            WpfnotepadSession = new WindowsDriver<WindowsElement>(new Uri(AppDriverUrl), appCapabilities);
             Assert.IsNotNull(WpfnotepadSession);
         }
         [TestMethod]

--- a/Samples/C#/WPFNotepadTest/WPFNotepadTest/WPFNotepadTest.csproj
+++ b/Samples/C#/WPFNotepadTest/WPFNotepadTest/WPFNotepadTest.csproj
@@ -38,8 +38,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver">
-      <HintPath>..\packages\Appium.WebDriver.2.0.1.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+    <Reference Include="appium-dotnet-driver, Version=3.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Appium.WebDriver.3.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core">
       <HintPath>..\packages\Castle.Core.4.0.0-beta002\lib\net45\Castle.Core.dll</HintPath>
@@ -54,11 +55,13 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="WebDriver">
-      <HintPath>..\packages\Selenium.WebDriver.3.0.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support">
-      <HintPath>..\packages\Selenium.Support.3.0.0\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/C#/WPFNotepadTest/WPFNotepadTest/packages.config
+++ b/Samples/C#/WPFNotepadTest/WPFNotepadTest/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="2.0.1.1" targetFramework="net45" />
+  <package id="Appium.WebDriver" version="3.0.0.1" targetFramework="net45" />
   <package id="Castle.Core" version="4.0.0-beta002" targetFramework="net45" />
   <package id="MSTest.TestAdapter" version="1.1.5-preview" targetFramework="net45" />
   <package id="MSTest.TestFramework" version="1.0.6-preview" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.2-beta1" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.0.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="3.0.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/Samples/C#/WordTest/Scenario.cs
+++ b/Samples/C#/WordTest/Scenario.cs
@@ -1,6 +1,6 @@
 using System;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace WordTest
@@ -14,7 +14,7 @@ namespace WordTest
         protected const string ExplorerAppId = @"C:\Windows\System32\explorer.exe";
         protected const string TestFileName = "NotepadTestOutputFile.txt";
         protected const string TargetSaveLocation = @"%TEMP%\";
-        protected static IOSDriver<IOSElement> WordSession;
+        protected static WindowsDriver<WindowsElement> WordSession;
 
         [ClassInitialize]
         public static void Setup(TestContext context)
@@ -22,7 +22,7 @@ namespace WordTest
             // Launch Word Classic Windows Application
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", WordAppId);
-            WordSession = new IOSDriver<IOSElement>(new Uri(AppDriverUrl), appCapabilities);
+            WordSession = new WindowsDriver<WindowsElement>(new Uri(AppDriverUrl), appCapabilities);
             Assert.IsNotNull(WordSession);
         }
         [TestMethod]

--- a/Samples/C#/WordTest/WordTest.csproj
+++ b/Samples/C#/WordTest/WordTest.csproj
@@ -40,8 +40,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver">
-      <HintPath>packages\Appium.WebDriver.2.0.1.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+    <Reference Include="appium-dotnet-driver, Version=3.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Appium.WebDriver.3.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core">
       <HintPath>packages\Castle.Core.4.0.0-beta002\lib\net45\Castle.Core.dll</HintPath>
@@ -56,11 +57,14 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="WebDriver">
-      <HintPath>packages\Selenium.WebDriver.3.0.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support">
-      <HintPath>packages\Selenium.Support.3.0.0\lib\net40\WebDriver.Support.dll</HintPath>
+    </Reference>
+    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/C#/WordTest/packages.config
+++ b/Samples/C#/WordTest/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="2.0.1.1" targetFramework="net45" />
+  <package id="Appium.WebDriver" version="3.0.0.1" targetFramework="net45" />
   <package id="Castle.Core" version="4.0.0-beta002" targetFramework="net45" />
   <package id="MSTest.TestAdapter" version="1.1.5-preview" targetFramework="net45" />
   <package id="MSTest.TestFramework" version="1.0.6-preview" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.2-beta1" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.0.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="3.0.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/Tests/Appium/AppClose.cs
+++ b/Tests/Appium/AppClose.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -28,7 +28,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", applicationId);
-            IOSDriver<IOSElement> session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
 
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);

--- a/Tests/Appium/AppLaunch.cs
+++ b/Tests/Appium/AppLaunch.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -29,7 +29,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
-            IOSDriver<IOSElement> session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -51,7 +51,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            IOSDriver<IOSElement> session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -75,7 +75,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.ExplorerAppId);
-            IOSDriver<IOSElement> session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 

--- a/Tests/Appium/Appium.csproj
+++ b/Tests/Appium/Appium.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Appium.WebDriver.2.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+    <Reference Include="appium-dotnet-driver, Version=3.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Appium.WebDriver.3.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
@@ -49,12 +49,12 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.Support.2.53.1\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Tests/Appium/packages.config
+++ b/Tests/Appium/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="2.0.0.1" targetFramework="net45" />
+  <package id="Appium.WebDriver" version="3.0.0.1" targetFramework="net45" />
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="Selenium.Support" version="2.53.1" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/Tests/UWPControls/Button.cs
+++ b/Tests/UWPControls/Button.cs
@@ -15,14 +15,14 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace UWPControls
 {
     [TestClass]
     public class Button : UWPControlsBase
     {
-        private IOSElement buttonElement = null;
+        private WindowsElement buttonElement = null;
 
         protected override void LoadScenarioView()
         {

--- a/Tests/UWPControls/CheckBox.cs
+++ b/Tests/UWPControls/CheckBox.cs
@@ -15,15 +15,15 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace UWPControls
 {
     [TestClass]
     public class CheckBox : UWPControlsBase
     {
-        private IOSElement checkBoxElement1 = null;
-        private IOSElement checkBoxElement2 = null;
+        private WindowsElement checkBoxElement1 = null;
+        private WindowsElement checkBoxElement2 = null;
 
         protected override void LoadScenarioView()
         {

--- a/Tests/UWPControls/RadioButton.cs
+++ b/Tests/UWPControls/RadioButton.cs
@@ -15,15 +15,15 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace UWPControls
 {
     [TestClass]
     public class RadioButton : UWPControlsBase
     {
-        private IOSElement radioButtonElement1 = null;
-        private IOSElement radioButtonElement2 = null;
+        private WindowsElement radioButtonElement1 = null;
+        private WindowsElement radioButtonElement2 = null;
 
         protected override void LoadScenarioView()
         {

--- a/Tests/UWPControls/Slider.cs
+++ b/Tests/UWPControls/Slider.cs
@@ -15,15 +15,15 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace UWPControls
 {
     [TestClass]
     public class Slider : UWPControlsBase
     {
-        private IOSElement sliderElement1 = null;
-        private IOSElement sliderElement2 = null;
+        private WindowsElement sliderElement1 = null;
+        private WindowsElement sliderElement2 = null;
 
         protected override void LoadScenarioView()
         {

--- a/Tests/UWPControls/ToggleSwitch.cs
+++ b/Tests/UWPControls/ToggleSwitch.cs
@@ -15,14 +15,14 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace UWPControls
 {
     [TestClass]
     public class ToggleSwitch : UWPControlsBase
     {
-        private IOSElement toggleSwitchElement = null;
+        private WindowsElement toggleSwitchElement = null;
 
         protected override void LoadScenarioView()
         {

--- a/Tests/UWPControls/UWPControls.csproj
+++ b/Tests/UWPControls/UWPControls.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver, Version=2.0.1.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Appium.WebDriver.2.0.1.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+    <Reference Include="appium-dotnet-driver, Version=3.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Appium.WebDriver.3.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
@@ -49,12 +49,12 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.Support.2.53.1\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Tests/UWPControls/UWPControlsBase.cs
+++ b/Tests/UWPControls/UWPControlsBase.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace UWPControls
@@ -25,7 +25,7 @@ namespace UWPControls
     {
         private const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
         private const string AppUIBasicAppId = "a5bd3fa2-e27f-49e9-9041-47c97e903ecc_8wekyb3d8bbwe!App";
-        protected static IOSDriver<IOSElement> session = null;
+        protected static WindowsDriver<WindowsElement> session = null;
 
         protected virtual void LoadScenarioView()
         {
@@ -42,7 +42,7 @@ namespace UWPControls
             // 3. The application will then be installed. You can safely close the AppUIBasics app & project
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", AppUIBasicAppId);
-            session = new IOSDriver<IOSElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
         }

--- a/Tests/UWPControls/packages.config
+++ b/Tests/UWPControls/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="2.0.1.1" targetFramework="net45" />
+  <package id="Appium.WebDriver" version="3.0.0.1" targetFramework="net45" />
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="Selenium.Support" version="2.53.1" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/Tests/W3CWebDriver/AlarmClockBase.cs
+++ b/Tests/W3CWebDriver/AlarmClockBase.cs
@@ -16,15 +16,15 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
 {
     public class AlarmClockBase
     {
-        protected static IOSDriver<IOSElement> session;
-        protected IOSElement alarmTabElement;
+        protected static WindowsDriver<WindowsElement> session;
+        protected WindowsElement alarmTabElement;
 
         public static void Setup(TestContext context)
         {
@@ -34,7 +34,7 @@ namespace W3CWebDriver
             // Launch Alarm Clock
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
         }

--- a/Tests/W3CWebDriver/Back.cs
+++ b/Tests/W3CWebDriver/Back.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -24,14 +24,14 @@ namespace W3CWebDriver
     [TestClass]
     public class Back
     {
-        private IOSDriver<IOSElement> session = null;
+        private WindowsDriver<WindowsElement> session = null;
 
         [TestMethod]
         public void NavigateBackBrowser()
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.EdgeAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
 
             session.FindElementByAccessibilityId("addressEditBox").SendKeys(CommonTestSettings.MicrosoftUrl + OpenQA.Selenium.Keys.Enter);
@@ -60,7 +60,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
 
             // Navigate to New Alarm view
@@ -81,7 +81,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.ExplorerAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
 
             System.Threading.Thread.Sleep(1000); // Sleep for 1 second
@@ -110,7 +110,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
 
             try

--- a/Tests/W3CWebDriver/Element.cs
+++ b/Tests/W3CWebDriver/Element.cs
@@ -15,7 +15,7 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace W3CWebDriver
 {
@@ -37,7 +37,7 @@ namespace W3CWebDriver
         [TestMethod]
         public void FindElementByAccessibilityId()
         {
-            IOSElement element = session.FindElementByAccessibilityId("AlarmPivotItem");
+            WindowsElement element = session.FindElementByAccessibilityId("AlarmPivotItem");
             Assert.IsNotNull(element);
             Assert.AreEqual(alarmTabElement, element);
         }
@@ -45,7 +45,7 @@ namespace W3CWebDriver
         [TestMethod]
         public void FindElementByClassName()
         {
-            IOSElement element = session.FindElementByClassName("PivotItem");
+            WindowsElement element = session.FindElementByClassName("PivotItem");
             Assert.IsNotNull(element);
             Assert.AreEqual(alarmTabElement, element);
         }
@@ -53,7 +53,7 @@ namespace W3CWebDriver
         [TestMethod]
         public void FindElementByName()
         {
-            IOSElement element = session.FindElementByName("More app bar");
+            WindowsElement element = session.FindElementByName("More app bar");
             Assert.IsNotNull(element);
         }
 
@@ -61,7 +61,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidAccessibilityId()
         {
-            IOSElement element = session.FindElementByAccessibilityId("InvalidAccessibiliyId");
+            WindowsElement element = session.FindElementByAccessibilityId("InvalidAccessibiliyId");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -69,7 +69,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidClassName()
         {
-            IOSElement element = session.FindElementByClassName("InvalidClassName");
+            WindowsElement element = session.FindElementByClassName("InvalidClassName");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -77,7 +77,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidName()
         {
-            IOSElement element = session.FindElementByName("InvalidName");
+            WindowsElement element = session.FindElementByName("InvalidName");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -85,7 +85,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidRuntimeId()
         {
-            IOSElement element = session.FindElementById("InvalidRuntimeId");
+            WindowsElement element = session.FindElementById("InvalidRuntimeId");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -93,7 +93,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidTagName()
         {
-            IOSElement element = session.FindElementByTagName("InvalidTagName");
+            WindowsElement element = session.FindElementByTagName("InvalidTagName");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -101,7 +101,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidTagNameMalformed()
         {
-            IOSElement element = session.FindElementByTagName("//@InvalidTagNameMalformed");
+            WindowsElement element = session.FindElementByTagName("//@InvalidTagNameMalformed");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -109,7 +109,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidXPath()
         {
-            IOSElement element = session.FindElementByXPath("//*//]");
+            WindowsElement element = session.FindElementByXPath("//*//]");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -117,7 +117,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByNonExistentXPath()
         {
-            IOSElement alarmTab = session.FindElementByXPath("//*[@Name=\"NonExistentElement\"]");
+            WindowsElement alarmTab = session.FindElementByXPath("//*[@Name=\"NonExistentElement\"]");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -125,7 +125,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(OpenQA.Selenium.WebDriverException))]
         public void ErrorFindElementByUnsupportedLocatorCSSSelector()
         {
-            IOSElement element = session.FindElementByCssSelector("Query");
+            WindowsElement element = session.FindElementByCssSelector("Query");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -133,7 +133,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(OpenQA.Selenium.WebDriverException))]
         public void ErrorFindElementByUnsupportedLocatorLinkText()
         {
-            IOSElement element = session.FindElementByLinkText("Query");
+            WindowsElement element = session.FindElementByLinkText("Query");
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -141,21 +141,21 @@ namespace W3CWebDriver
         [ExpectedException(typeof(OpenQA.Selenium.WebDriverException))]
         public void ErrorFindElementByUnsupportedLocatorPartialLinkText()
         {
-            IOSElement element = session.FindElementByPartialLinkText("Query");
+            WindowsElement element = session.FindElementByPartialLinkText("Query");
             Assert.Fail("Exception should have been thrown");
         }
 
         [TestMethod]
         public void FindElementByTagName()
         {
-            IOSElement element = session.FindElementByTagName("Button");
+            WindowsElement element = session.FindElementByTagName("Button");
             Assert.IsNotNull(element);
         }
 
         [TestMethod]
         public void FindElementByXPath()
         {
-            IOSElement alarmTab = session.FindElementByXPath("//Button[@AutomationId=\"MoreButton\"]");
+            WindowsElement alarmTab = session.FindElementByXPath("//Button[@AutomationId=\"MoreButton\"]");
             Assert.IsNotNull(alarmTab);
         }
     }

--- a/Tests/W3CWebDriver/ElementElement.cs
+++ b/Tests/W3CWebDriver/ElementElement.cs
@@ -15,7 +15,7 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace W3CWebDriver
 {
@@ -37,10 +37,10 @@ namespace W3CWebDriver
         [TestMethod]
         public void FindElementByAccessibilityId()
         {
-            IOSElement element = alarmTabElement.FindElementByAccessibilityId("AlarmListView") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByAccessibilityId("AlarmListView") as WindowsElement;
             Assert.IsNotNull(element);
 
-            IOSElement alarmListViewElement = session.FindElementByAccessibilityId("AlarmListView") as IOSElement;
+            WindowsElement alarmListViewElement = session.FindElementByAccessibilityId("AlarmListView") as WindowsElement;
             Assert.IsNotNull(alarmListViewElement);
 
             Assert.AreEqual(alarmListViewElement, element);
@@ -49,14 +49,14 @@ namespace W3CWebDriver
         [TestMethod]
         public void FindElementByClassName()
         {
-            IOSElement element = alarmTabElement.FindElementByClassName("ListView") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByClassName("ListView") as WindowsElement;
             Assert.IsNotNull(element);
         }
 
         [TestMethod]
         public void FindElementByName()
         {
-            IOSElement element = alarmTabElement.FindElementByName("More app bar") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByName("More app bar") as WindowsElement;
             Assert.IsNotNull(element);
         }
 
@@ -64,7 +64,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidAccessibilityId()
         {
-            IOSElement element = alarmTabElement.FindElementByAccessibilityId("InvalidAccessibiliyId") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByAccessibilityId("InvalidAccessibiliyId") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -72,7 +72,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidClassName()
         {
-            IOSElement element = alarmTabElement.FindElementByClassName("InvalidClassName") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByClassName("InvalidClassName") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -80,7 +80,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidName()
         {
-            IOSElement element = alarmTabElement.FindElementByName("InvalidName") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByName("InvalidName") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -88,7 +88,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidRuntimeId()
         {
-            IOSElement element = alarmTabElement.FindElementById("InvalidRuntimeId") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementById("InvalidRuntimeId") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -96,7 +96,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidTagName()
         {
-            IOSElement element = alarmTabElement.FindElementByTagName("InvalidTagName") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByTagName("InvalidTagName") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -104,7 +104,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidTagNameMalformed()
         {
-            IOSElement element = alarmTabElement.FindElementByTagName("//@InvalidTagNameMalformed") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByTagName("//@InvalidTagNameMalformed") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -112,7 +112,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByInvalidXPath()
         {
-            IOSElement element = alarmTabElement.FindElementByXPath("//*//]") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByXPath("//*//]") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -120,7 +120,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(System.InvalidOperationException))]
         public void ErrorFindElementByNonExistentXPath()
         {
-            IOSElement element = session.FindElementByXPath("//*[@Name=\"NonExistentElement\"]") as IOSElement;
+            WindowsElement element = session.FindElementByXPath("//*[@Name=\"NonExistentElement\"]") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -128,7 +128,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(OpenQA.Selenium.WebDriverException))]
         public void ErrorFindElementByUnsupportedLocatorCSSSelector()
         {
-            IOSElement element = alarmTabElement.FindElementByCssSelector("Query") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByCssSelector("Query") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -136,7 +136,7 @@ namespace W3CWebDriver
         [ExpectedException(typeof(OpenQA.Selenium.WebDriverException))]
         public void ErrorFindElementByUnsupportedLocatorLinkText()
         {
-            IOSElement element = alarmTabElement.FindElementByLinkText("Query") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByLinkText("Query") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -144,21 +144,21 @@ namespace W3CWebDriver
         [ExpectedException(typeof(OpenQA.Selenium.WebDriverException))]
         public void ErrorFindElementByUnsupportedLocatorPartialLinkText()
         {
-            IOSElement element = alarmTabElement.FindElementByPartialLinkText("Query") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByPartialLinkText("Query") as WindowsElement;
             Assert.Fail("Exception should have been thrown");
         }
 
         [TestMethod]
         public void FindElementByTagName()
         {
-            IOSElement element = alarmTabElement.FindElementByTagName("Button") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByTagName("Button") as WindowsElement;
             Assert.IsNotNull(element);
         }
 
         [TestMethod]
         public void FindElementByXPath()
         {
-            IOSElement element = alarmTabElement.FindElementByXPath("//Button[@AutomationId=\"MoreButton\"]") as IOSElement;
+            WindowsElement element = alarmTabElement.FindElementByXPath("//Button[@AutomationId=\"MoreButton\"]") as WindowsElement;
             Assert.IsNotNull(element);
         }
     }

--- a/Tests/W3CWebDriver/ElementElements.cs
+++ b/Tests/W3CWebDriver/ElementElements.cs
@@ -15,14 +15,14 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace W3CWebDriver
 {
     [TestClass]
     public class ElementElements : AlarmClockBase
     {
-        private static IOSElement homePagePivot;
+        private static WindowsElement homePagePivot;
 
         [ClassInitialize]
         public static void ClassInitialize(TestContext context)

--- a/Tests/W3CWebDriver/ElementSendKeys.cs
+++ b/Tests/W3CWebDriver/ElementSendKeys.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -24,15 +24,15 @@ namespace W3CWebDriver
     [TestClass]
     public class ElementSendKeys
     {
-        protected static IOSDriver<IOSElement> session;
-        protected static IOSElement editBox;
+        protected static WindowsDriver<WindowsElement> session;
+        protected static WindowsElement editBox;
 
         [ClassInitialize]
         public static void ClassInitialize(TestContext context)
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -162,7 +162,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "Root");
-            IOSDriver<IOSElement> desktopSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> desktopSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(desktopSession);
 
             // Lauch action center using Window Keys + A

--- a/Tests/W3CWebDriver/Elements.cs
+++ b/Tests/W3CWebDriver/Elements.cs
@@ -15,7 +15,7 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace W3CWebDriver
 {

--- a/Tests/W3CWebDriver/Forward.cs
+++ b/Tests/W3CWebDriver/Forward.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -24,14 +24,14 @@ namespace W3CWebDriver
     [TestClass]
     public class Forward
     {
-        private IOSDriver<IOSElement> session = null;
+        private WindowsDriver<WindowsElement> session = null;
 
         [TestMethod]
         public void NavigateForwardBrowser()
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.EdgeAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
 
             session.FindElementByAccessibilityId("addressEditBox").SendKeys(CommonTestSettings.MicrosoftUrl + OpenQA.Selenium.Keys.Enter);
@@ -63,7 +63,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.ExplorerAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
 
             var originalTitle = session.Title;
@@ -95,7 +95,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
 
             try

--- a/Tests/W3CWebDriver/Keys.cs
+++ b/Tests/W3CWebDriver/Keys.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -24,15 +24,15 @@ namespace W3CWebDriver
     [TestClass]
     public class Keys
     {
-        protected static IOSDriver<IOSElement> session;
-        protected static IOSElement editBox;
+        protected static WindowsDriver<WindowsElement> session;
+        protected static WindowsElement editBox;
 
         [ClassInitialize]
         public static void ClassInitialize(TestContext context)
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -163,7 +163,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "Root");
-            IOSDriver<IOSElement> desktopSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> desktopSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(desktopSession);
 
             // Lauch action center using Window Keys + A

--- a/Tests/W3CWebDriver/Orientation.cs
+++ b/Tests/W3CWebDriver/Orientation.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -24,14 +24,14 @@ namespace W3CWebDriver
     [TestClass]
     public class Orientation
     {
-        private IOSDriver<IOSElement> session = null;
+        private WindowsDriver<WindowsElement> session = null;
 
         [TestMethod]
         public void GetOrientation()
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -48,7 +48,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 

--- a/Tests/W3CWebDriver/Screenshot.cs
+++ b/Tests/W3CWebDriver/Screenshot.cs
@@ -19,7 +19,7 @@ using System.Net;
 using System.Drawing;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -42,7 +42,7 @@ namespace W3CWebDriver
         [TestMethod]
         public void GetAlarmPivotItemScreenshot()
         {
-            IOSElement element = session.FindElementByAccessibilityId("AlarmPivotItem");
+            WindowsElement element = session.FindElementByAccessibilityId("AlarmPivotItem");
             var screenshot = element.GetScreenshot();
             using (MemoryStream msScreenshot = new MemoryStream(screenshot.AsByteArray))
             {
@@ -55,7 +55,7 @@ namespace W3CWebDriver
         [TestMethod]
         public void GetWorldClockScreenshot()
         {
-            IOSElement element = session.FindElementByAccessibilityId("WorldClockPivotItem");
+            WindowsElement element = session.FindElementByAccessibilityId("WorldClockPivotItem");
             var screenshot = element.GetScreenshot();
             using (MemoryStream msScreenshot = new MemoryStream(screenshot.AsByteArray))
             {
@@ -68,7 +68,7 @@ namespace W3CWebDriver
         [TestMethod]
         public void GetAddAlarmScreenshot()
         {
-            IOSElement element = session.FindElementByAccessibilityId("AddAlarmButton");
+            WindowsElement element = session.FindElementByAccessibilityId("AddAlarmButton");
             var screenshot = element.GetScreenshot();
             using (MemoryStream msScreenshot = new MemoryStream(screenshot.AsByteArray))
             {
@@ -81,7 +81,7 @@ namespace W3CWebDriver
         [TestMethod]
         public void GetAlarmListScreenshot()
         {
-            IOSElement element = session.FindElementByAccessibilityId("AlarmListView");
+            WindowsElement element = session.FindElementByAccessibilityId("AlarmListView");
             var screenshot = element.GetScreenshot();
             using (MemoryStream msScreenshot = new MemoryStream(screenshot.AsByteArray))
             {
@@ -109,7 +109,7 @@ namespace W3CWebDriver
             // Launch calculator for this specific test case
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            IOSDriver<IOSElement> calculatorSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> calculatorSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(calculatorSession);
             Assert.IsNotNull(calculatorSession.SessionId);
 
@@ -143,7 +143,7 @@ namespace W3CWebDriver
         public void ErrorGetStaleElementScreenshot()
         {
             session.FindElementByAccessibilityId("StopwatchPivotItem").Click();
-            IOSElement element = session.FindElementByAccessibilityId("StopwatchPlayPauseButton");
+            WindowsElement element = session.FindElementByAccessibilityId("StopwatchPlayPauseButton");
             var screenshot1 = element.GetScreenshot();
             using (MemoryStream msScreenshot1 = new MemoryStream(screenshot1.AsByteArray))
             {
@@ -165,14 +165,14 @@ namespace W3CWebDriver
             // Launch calculator for this specific test case
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            IOSDriver<IOSElement> calculatorSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> calculatorSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(calculatorSession);
             Assert.IsNotNull(calculatorSession.SessionId);
 
             try
             {
                 calculatorSession.Close();
-                IOSElement element = calculatorSession.FindElementByAccessibilityId("AppNameTitle");
+                WindowsElement element = calculatorSession.FindElementByAccessibilityId("AppNameTitle");
                 element.GetScreenshot();
                 Assert.Fail("Exception should have been thrown because there is no such window");
             }

--- a/Tests/W3CWebDriver/Selected.cs
+++ b/Tests/W3CWebDriver/Selected.cs
@@ -15,7 +15,7 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 
 namespace W3CWebDriver
 {
@@ -37,8 +37,8 @@ namespace W3CWebDriver
         [TestMethod]
         public void FindSelectedElement()
         {
-            IOSElement elementWorldClock = session.FindElementByAccessibilityId("WorldClockPivotItem");
-            IOSElement elementAlarmClock = session.FindElementByAccessibilityId("AlarmPivotItem");
+            WindowsElement elementWorldClock = session.FindElementByAccessibilityId("WorldClockPivotItem");
+            WindowsElement elementAlarmClock = session.FindElementByAccessibilityId("AlarmPivotItem");
 
             elementWorldClock.Click();
             Assert.IsTrue(elementWorldClock.Selected);
@@ -51,7 +51,7 @@ namespace W3CWebDriver
         [TestMethod]
         public void ErrorFindUnselectableElement()
         {
-            IOSElement elementAddButton = session.FindElementByAccessibilityId("AddAlarmButton");
+            WindowsElement elementAddButton = session.FindElementByAccessibilityId("AddAlarmButton");
             Assert.IsFalse(elementAddButton.Selected);
         }
     }

--- a/Tests/W3CWebDriver/Session.cs
+++ b/Tests/W3CWebDriver/Session.cs
@@ -18,7 +18,7 @@ using System;
 using System.IO;
 using System.Net;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -26,14 +26,14 @@ namespace W3CWebDriver
     [TestClass]
     public class Session
     {
-        private IOSDriver<IOSElement> session = null;
+        private WindowsDriver<WindowsElement> session = null;
 
         [TestMethod]
         public void CreateSessionClassicApp()
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             session.Quit();
@@ -45,7 +45,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "Root");
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             session.Quit();
@@ -57,7 +57,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             session.Quit();
@@ -69,7 +69,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.ExplorerAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             session.Quit();
@@ -82,7 +82,7 @@ namespace W3CWebDriver
             DesiredCapabilities supportedCapabilities = new DesiredCapabilities();
             supportedCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
             supportedCapabilities.SetCapability("platformVersion", "10");
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), supportedCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), supportedCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             session.Quit();
@@ -95,7 +95,7 @@ namespace W3CWebDriver
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
             appCapabilities.SetCapability("anUnsupportedCapabilities", "Unsupported Capabilities Value");
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             session.Quit();
@@ -107,7 +107,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -120,7 +120,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "Root");
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -134,7 +134,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -148,7 +148,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.ExplorerAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -163,7 +163,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "BadAppId");
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -173,7 +173,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", @"C:\Windows\System32\BadAppId.exe");
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -183,7 +183,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "Microsoft.BadAppId!App");
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -192,7 +192,7 @@ namespace W3CWebDriver
         public void ErrorCreateSessionMissingArgumentAppId()
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities(); // Leave capabilities empty
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.Fail("Exception should have been thrown");
         }
 
@@ -211,7 +211,7 @@ namespace W3CWebDriver
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
 
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -228,7 +228,7 @@ namespace W3CWebDriver
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
 
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -242,19 +242,19 @@ namespace W3CWebDriver
         [TestMethod]
         public void MultipleSessions()
         {
-            IOSDriver<IOSElement> session1 = null;
-            IOSDriver<IOSElement> session2 = null;
+            WindowsDriver<WindowsElement> session1 = null;
+            WindowsDriver<WindowsElement> session2 = null;
 
             try
             {
                 DesiredCapabilities appCapabilities = new DesiredCapabilities();
                 appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
 
-                session1 = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+                session1 = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
                 Assert.IsNotNull(session1);
                 Assert.IsNotNull(session1.SessionId);
 
-                session2 = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+                session2 = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
                 Assert.IsNotNull(session2);
                 Assert.IsNotNull(session2.SessionId);
 
@@ -281,19 +281,19 @@ namespace W3CWebDriver
         [TestMethod]
         public void MultipleSessionsSingleInstanceApplication()
         {
-            IOSDriver<IOSElement> session1 = null;
-            IOSDriver<IOSElement> session2 = null;
+            WindowsDriver<WindowsElement> session1 = null;
+            WindowsDriver<WindowsElement> session2 = null;
 
             try
             {
                 DesiredCapabilities appCapabilities = new DesiredCapabilities();
                 appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
 
-                session1 = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+                session1 = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
                 Assert.IsNotNull(session1);
                 Assert.IsNotNull(session1.SessionId);
 
-                session2 = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+                session2 = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
                 Assert.IsNotNull(session2);
                 Assert.IsNotNull(session2.SessionId);
 

--- a/Tests/W3CWebDriver/Sessions.cs
+++ b/Tests/W3CWebDriver/Sessions.cs
@@ -19,7 +19,7 @@ using System.IO;
 using System.Net;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -62,7 +62,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            IOSDriver<IOSElement> session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
 
             using (HttpWebResponse response = WebRequest.Create(CommonTestSettings.WindowsApplicationDriverUrl + "/sessions").GetResponse() as HttpWebResponse)
@@ -87,12 +87,12 @@ namespace W3CWebDriver
         {
             DesiredCapabilities alarmAppCapabilities = new DesiredCapabilities();
             alarmAppCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            IOSDriver<IOSElement> alarmSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), alarmAppCapabilities);
+            WindowsDriver<WindowsElement> alarmSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), alarmAppCapabilities);
             Assert.IsNotNull(alarmSession);
 
             DesiredCapabilities notepadAppCapabilities = new DesiredCapabilities();
             notepadAppCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
-            IOSDriver<IOSElement> notepadSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), notepadAppCapabilities);
+            WindowsDriver<WindowsElement> notepadSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), notepadAppCapabilities);
             Assert.IsNotNull(notepadSession);
 
             using (HttpWebResponse response = WebRequest.Create(CommonTestSettings.WindowsApplicationDriverUrl + "/sessions").GetResponse() as HttpWebResponse)

--- a/Tests/W3CWebDriver/Title.cs
+++ b/Tests/W3CWebDriver/Title.cs
@@ -16,7 +16,7 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -24,14 +24,14 @@ namespace W3CWebDriver
     [TestClass]
     public class Title
     {
-        private IOSDriver<IOSElement> session = null;
+        private WindowsDriver<WindowsElement> session = null;
 
         [TestMethod]
         public void GetTitleClassicApp()
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             Assert.AreEqual("Untitled - Notepad", session.Title);
@@ -44,7 +44,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", "Root");
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             Assert.AreEqual("Desktop", session.Title);
@@ -57,7 +57,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             Assert.AreEqual("Calculator", session.Title);
@@ -70,7 +70,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
             Assert.AreEqual("Calculator", session.Title);

--- a/Tests/W3CWebDriver/TouchBase.cs
+++ b/Tests/W3CWebDriver/TouchBase.cs
@@ -21,14 +21,14 @@ using System.Net;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
 {
     public class TouchBase
     {
-        protected static IOSDriver<IOSElement> session;
+        protected static WindowsDriver<WindowsElement> session;
         protected static RemoteTouchScreen touchScreen;
         protected static string startingPageTitle = string.Empty;
         private const int maxNavigationHistory = 5;
@@ -41,7 +41,7 @@ namespace W3CWebDriver
             // Launch the Edge browser app
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.EdgeAppId);
-            session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -101,7 +101,7 @@ namespace W3CWebDriver
             }
         }
 
-        protected RemoteWebElement GetOrphanedElement(IOSDriver<IOSElement> remoteSession)
+        protected RemoteWebElement GetOrphanedElement(WindowsDriver<WindowsElement> remoteSession)
         {
             RemoteWebElement orphanedElement = null;
 
@@ -150,7 +150,7 @@ namespace W3CWebDriver
             return orphanedElement;
         }
 
-        protected static RemoteWebElement GetStaleElement(IOSDriver<IOSElement> remoteSession)
+        protected static RemoteWebElement GetStaleElement(WindowsDriver<WindowsElement> remoteSession)
         {
             RemoteWebElement staleElement = null;
 

--- a/Tests/W3CWebDriver/TouchDoubleClick.cs
+++ b/Tests/W3CWebDriver/TouchDoubleClick.cs
@@ -15,7 +15,7 @@
 //******************************************************************************
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 using System;
 
@@ -24,7 +24,7 @@ namespace W3CWebDriver
     [TestClass]
     public class TouchDoubleClick : TouchBase
     {
-        private static IOSDriver<IOSElement> calculatorSession;
+        private static WindowsDriver<WindowsElement> calculatorSession;
         private static RemoteTouchScreen calculatorTouchScreen;
 
         [ClassInitialize]
@@ -54,7 +54,7 @@ namespace W3CWebDriver
             // Launch calculator for this specific test case
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            calculatorSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            calculatorSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(calculatorSession);
             Assert.IsNotNull(calculatorSession.SessionId);
 

--- a/Tests/W3CWebDriver/W3CWebDriver.csproj
+++ b/Tests/W3CWebDriver/W3CWebDriver.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="appium-dotnet-driver, Version=2.0.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Appium.WebDriver.2.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
+    <Reference Include="appium-dotnet-driver, Version=3.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Appium.WebDriver.3.0.0.1\lib\net45\appium-dotnet-driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
@@ -50,12 +50,12 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.XML" />
-    <Reference Include="WebDriver, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.WebDriver.3.0.1\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Selenium.Support.2.53.1\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Selenium.Support.3.0.1\lib\net40\WebDriver.Support.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Tests/W3CWebDriver/Window.cs
+++ b/Tests/W3CWebDriver/Window.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
 
 namespace W3CWebDriver
@@ -30,7 +30,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            IOSDriver<IOSElement> singleWindowSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> singleWindowSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(singleWindowSession);
             Assert.IsNotNull(singleWindowSession.SessionId);
 
@@ -48,7 +48,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            IOSDriver<IOSElement> session = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> session = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(session);
             Assert.IsNotNull(session.SessionId);
 
@@ -64,7 +64,7 @@ namespace W3CWebDriver
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
 
-            IOSDriver<IOSElement> multiWindowsSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> multiWindowsSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(multiWindowsSession);
             Assert.IsNotNull(multiWindowsSession.SessionId);
 
@@ -79,7 +79,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.NotepadAppId);
-            IOSDriver<IOSElement> multiWindowsSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> multiWindowsSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(multiWindowsSession);
             Assert.IsNotNull(multiWindowsSession.SessionId);
 
@@ -109,7 +109,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.EdgeAppId);
-            IOSDriver<IOSElement> multiWindowsSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> multiWindowsSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(multiWindowsSession);
             Assert.IsNotNull(multiWindowsSession.SessionId);
 
@@ -161,7 +161,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.EdgeAppId);
-            IOSDriver<IOSElement> multiWindowsSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> multiWindowsSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(multiWindowsSession);
             Assert.IsNotNull(multiWindowsSession.SessionId);
 
@@ -213,7 +213,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            IOSDriver<IOSElement> singleWindowSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> singleWindowSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(singleWindowSession);
             Assert.IsNotNull(singleWindowSession.SessionId);
 
@@ -241,7 +241,7 @@ namespace W3CWebDriver
         {
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.AlarmClockAppId);
-            IOSDriver<IOSElement> singleWindowSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowsDriver<WindowsElement> singleWindowSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(singleWindowSession);
             Assert.IsNotNull(singleWindowSession.SessionId);
 
@@ -267,7 +267,7 @@ namespace W3CWebDriver
     [TestClass]
     public class WindowTransform
     {
-        protected static IOSDriver<IOSElement> WindowTransformSession;   // Temporary placeholder until Windows namespace exists
+        protected static WindowsDriver<WindowsElement> WindowTransformSession;   // Temporary placeholder until Windows namespace exists
         protected static System.Drawing.Size OriginalSize;
         protected static System.Drawing.Point OriginalPosition;
 
@@ -277,7 +277,7 @@ namespace W3CWebDriver
             // Launch the Calculator app
             DesiredCapabilities appCapabilities = new DesiredCapabilities();
             appCapabilities.SetCapability("app", CommonTestSettings.CalculatorAppId);
-            WindowTransformSession = new IOSDriver<IOSElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
+            WindowTransformSession = new WindowsDriver<WindowsElement>(new Uri(CommonTestSettings.WindowsApplicationDriverUrl), appCapabilities);
             Assert.IsNotNull(WindowTransformSession);
         }
 

--- a/Tests/W3CWebDriver/Window.cs
+++ b/Tests/W3CWebDriver/Window.cs
@@ -267,7 +267,7 @@ namespace W3CWebDriver
     [TestClass]
     public class WindowTransform
     {
-        protected static WindowsDriver<WindowsElement> WindowTransformSession;   // Temporary placeholder until Windows namespace exists
+        protected static WindowsDriver<WindowsElement> WindowTransformSession;
         protected static System.Drawing.Size OriginalSize;
         protected static System.Drawing.Point OriginalPosition;
 

--- a/Tests/W3CWebDriver/packages.config
+++ b/Tests/W3CWebDriver/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Appium.WebDriver" version="2.0.0.1" targetFramework="net45" />
+  <package id="Appium.WebDriver" version="3.0.0.1" targetFramework="net45" />
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="Selenium.Support" version="2.53.1" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.0.1" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The [3.0.0.1 release of the Appium.WebDriver package](https://github.com/appium/appium-dotnet-driver/blob/master/RELEASE_NOTES.md#3001) provides a WindowsDriver class which can be used in place of IOSDriver.  This PR updates the Appium.WebDriver package (and it's dependencies) in each of the C# projects and changes all namespaces/classnames to use WindowsDriver/WindowsElement in place of IOSDriver/IOSElement.

This has not been well tested as I experienced failures in many unit tests, even prior to making the changes.  In fact, I couldn't even build the WordTest and WPFNotepadTest projects.