### PR TITLE
Update calculatortest.py

### DIFF
--- a/Samples/Python/calculatortest.py
+++ b/Samples/Python/calculatortest.py
@@ -37,7 +37,7 @@ class SimpleCalculatorTests(unittest.TestCase):
 		self.driver.find_element_by_name("Seven").click()
 
 		result = self.driver.find_element_by_accessibility_id("CalculatorResults")
-		self.assertEqual(str(result.text),"Display is  7 ")
+		self.assertEqual(str(result.text),"Display is 7")
 
 	def test_addition(self):
 		self.driver.find_element_by_name("One").click()
@@ -46,7 +46,7 @@ class SimpleCalculatorTests(unittest.TestCase):
 		self.driver.find_element_by_name("Equals").click()
 
 		result = self.driver.find_element_by_accessibility_id("CalculatorResults")
-		self.assertEqual(str(result.text), "Display is  8 ")
+		self.assertEqual(str(result.text), "Display is 8")
 
 	def test_combination(self):
 		self.driver.find_element_by_name("Seven").click()
@@ -60,7 +60,7 @@ class SimpleCalculatorTests(unittest.TestCase):
 		self.driver.find_element_by_name("Equals").click()
 
 		result = self.driver.find_element_by_accessibility_id("CalculatorResults")
-		self.assertEqual(str(result.text), "Display is  8 ")
+		self.assertEqual(str(result.text), "Display is 8")
 
 	def test_division(self):
 		self.driver.find_element_by_name("Eight").click()
@@ -71,7 +71,7 @@ class SimpleCalculatorTests(unittest.TestCase):
 		self.driver.find_element_by_name("Equals").click()
 		
 		result = self.driver.find_element_by_accessibility_id("CalculatorResults")
-		self.assertEqual(str(result.text), "Display is  8 ")
+		self.assertEqual(str(result.text), "Display is 8")
 
 	def test_multiplication(self):
 		self.driver.find_element_by_name("Nine").click()
@@ -80,7 +80,7 @@ class SimpleCalculatorTests(unittest.TestCase):
 		self.driver.find_element_by_name("Equals").click()
 
 		result = self.driver.find_element_by_accessibility_id("CalculatorResults")
-		self.assertEqual(str(result.text), "Display is  81 ")
+		self.assertEqual(str(result.text), "Display is 81")
 
 	def test_subtraction(self):
 		self.driver.find_element_by_name("Nine").click()
@@ -89,7 +89,7 @@ class SimpleCalculatorTests(unittest.TestCase):
 		self.driver.find_element_by_name("Equals").click()
 
 		result = self.driver.find_element_by_accessibility_id("CalculatorResults")
-		self.assertEqual(str(result.text), "Display is  8 ")
+		self.assertEqual(str(result.text), "Display is 8")
 
 
 


### PR DESCRIPTION
Due to recent windows 10 updates the element "CalculatorResults" value  change to "Display is x" instead of "Display is  x "

Before Display is X had 2 extra spaces, one before the number and one after the number.