### PR TITLE
Add missing documentation regarding Developer Mode and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ For answers to common questions and/or best practices in using WinAppDriver, ple
 
 1. Download Windows Application Driver installer from <https://github.com/Microsoft/WinAppDriver/releases>
 2. Run the installer on a Windows 10 machine where your application under test is installed and will be tested
-3. Run `WinAppDriver.exe` from the installation directory (E.g. `C:\Program Files (x86)\Windows Application Driver`)
+3. Enable [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development) in Windows settings
+4. Run `WinAppDriver.exe` from the installation directory (E.g. `C:\Program Files (x86)\Windows Application Driver`)
 
 Windows Application Driver will then be running on the test machine listening to requests on the default IP address and port (`127.0.0.1:4723`). You can then run any of our [Tests](/Tests/) or [Samples](/Samples). `WinAppDriver.exe` can be configured to listen to a different IP address and port as follows:
 

--- a/Samples/C#/CalculatorTest/ScenarioStandard.cs
+++ b/Samples/C#/CalculatorTest/ScenarioStandard.cs
@@ -30,7 +30,7 @@ namespace CalculatorTest
         [TestMethod]
         public void Addition()
         {
-            // Find the buttons by their names and click them in sequence to peform 1 + 7 = 8
+            // Find the buttons by their names and click them in sequence to perform 1 + 7 = 8
             session.FindElementByName("One").Click();
             session.FindElementByName("Plus").Click();
             session.FindElementByName("Seven").Click();

--- a/Samples/Ruby/features/standard.feature
+++ b/Samples/Ruby/features/standard.feature
@@ -6,7 +6,7 @@ Feature: Standard calculator
     Given I start the application
      Then I see the result is "0"
 
-  # Find the buttons by their names and click them in sequence to peform 1 + 7 = 8
+  # Find the buttons by their names and click them in sequence to perform 1 + 7 = 8
   Scenario: Addition
     Given I start the application
      When I press "One"


### PR DESCRIPTION
Trying to run WinAppDriver without Developer mode enabled will result in an error telling the user to enable Developer mode first. This requirement isn't mentioned in the docs, so I added it. I also fixed a couple typos.