### PR TITLE
Workaround for issue #507.

### DIFF
--- a/Samples/C#/NotepadTest/NotepadSession.cs
+++ b/Samples/C#/NotepadTest/NotepadSession.cs
@@ -81,5 +81,7 @@ namespace NotepadTest
             editBox.SendKeys(Keys.Delete);
             Assert.AreEqual(string.Empty, editBox.Text);
         }
+
+        protected static string SanitizeBackslashes(string input) => input.Replace("\\", Keys.Alt + Keys.NumberPad9 + Keys.NumberPad2 + Keys.Alt);
     }
 }

--- a/Samples/C#/NotepadTest/ScenarioPopupDialog.cs
+++ b/Samples/C#/NotepadTest/ScenarioPopupDialog.cs
@@ -36,7 +36,7 @@ namespace NotepadTest
             session.FindElementByName("File").Click();
             session.FindElementByXPath($"//MenuItem[starts-with(@Name, \"Save As\")]").Click();
             Thread.Sleep(TimeSpan.FromSeconds(1)); // Wait for 1 second until the save dialog appears
-            session.FindElementByAccessibilityId("FileNameControlHost").SendKeys(TargetSaveLocation + TestFileName);
+            session.FindElementByAccessibilityId("FileNameControlHost").SendKeys(SanitizeBackslashes(TargetSaveLocation + TestFileName));
             session.FindElementByName("Save").Click();
 
             // Check if the Save As dialog appears when there's a leftover test file from previous test run
@@ -70,7 +70,7 @@ namespace NotepadTest
             Assert.IsNotNull(windowsExplorerSession);
 
             // Navigate Windows Explorer to the target save location folder
-            windowsExplorerSession.Keyboard.SendKeys(Keys.Alt + "d" + Keys.Alt + TargetSaveLocation + Keys.Enter);
+            windowsExplorerSession.Keyboard.SendKeys(Keys.Alt + "d" + Keys.Alt + SanitizeBackslashes(TargetSaveLocation) + Keys.Enter);
 
             // Verify that the file is indeed saved in the working directory and delete it
             windowsExplorerSession.FindElementByAccessibilityId("SearchEditBox").SendKeys(TestFileName + Keys.Enter);


### PR DESCRIPTION
I encountered this issue whilst running the Notepad tests:

https://stackoverflow.com/questions/52533272/winappdriver-and-appium-send-keys-sending-a-in-place-of

This PR implements the suggested workaround. Tested on UK keyboard layout.