### PR TITLE
Add VS 2019 to list of Visual Studio versions in "Writing Automated Tests" doc

### DIFF
--- a/Docs/AuthoringTestScripts.md
+++ b/Docs/AuthoringTestScripts.md
@@ -4,7 +4,7 @@ You can choose any programming language or tools supported by Appium/Selenium to
 
 ### Creating a Test Project
 
-1. Open **Microsoft Visual Studio 2015** or **Microsoft Visual Studio 2017**
+1. Open **Microsoft Visual Studio 2015**, **Microsoft Visual Studio 2017** or **Microsoft Visual Studio 2019**
    > **Note**: in Visual Studio 2017 make sure you have the optional **.NET desktop development** workload installed
 2. Create the test project and solution. I.e. Select **New Project > Templates > Visual C# > Test > Unit Test Project**
 3. Once created, select **Project > Manage NuGet Packages... > Browse** and search for **Appium.WebDriver**


### PR DESCRIPTION
Since VS 2019 has been available for quite a while now and a docs only mentioning VS 2015 and VS 2017 seem odd, especially with VS 2022 on the horizon. This PR adds VS 2019 to the list of options.