### PR TITLE
fix regexp for name value pattern of xpath

### DIFF
--- a/Tools/UIRecorder/UIRecorder/GenerateXPath.cs
+++ b/Tools/UIRecorder/UIRecorder/GenerateXPath.cs
@@ -330,7 +330,7 @@ namespace WinAppDriverUIRecorder
 
             foreach (string attrNameValue in listAttrs)
             {
-                const string patternNameValue = @"\[([^=]+)=([^\]]+)\]";
+                const string patternNameValue = @"\[([^=]+)=(\""[^\""]+\""|[\d\.]+)\]";
                 var regNameValue = new System.Text.RegularExpressions.Regex(patternNameValue, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
                 System.Text.RegularExpressions.Match matchNameValue = regNameValue.Match(attrNameValue);
                 if (matchNameValue.Success)


### PR DESCRIPTION
I found that the UI Recorder does not recognize the path correctly if the Name attribute contains `]`.
For example, in a mailer, the subject of the selected mail may be set to the Name attribute of the UI element, which causes a lot of misrecognition.
And I found that there was a mistake in the regular expression and fixed it.