### PR TITLE
Fix DoubleClick, ContextClick in the UI Recorder

### DIFF
--- a/Tools/UIRecorder/UIRecorder/RecordedUiTask.cs
+++ b/Tools/UIRecorder/UIRecorder/RecordedUiTask.cs
@@ -304,16 +304,16 @@ namespace WinAppDriverUIRecorder
 
         public static string DoubleClick(RecordedUiTask uiTask, string elemName)
         {
-            string codeLine = $"    desktopSession.DesktopSessionElement.Mouse.MouseMove(winElem_{elemName}.Coordinates);\n" +
-                            $"    desktopSession.DesktopSessionElement.Mouse.DoubleClick(null);\n";
+            string codeLine = $"    Actions actions = new Actions(desktopSession.DesktopSessionElement);\n" +
+                            $"    actions.DoubleClick(winElem_{elemName}).Build().Perform();\n";
 
             return GetCodeBlock(uiTask, elemName, codeLine);
         }
 
         public static string RightClick(RecordedUiTask uiTask, string elemName)
         {
-            string codeLine = $"    desktopSession.DesktopSessionElement.Mouse.MouseMove(winElem_{elemName}.Coordinates);\n" +
-                            $"    desktopSession.DesktopSessionElement.Mouse.ContextClick(null);\n";
+            string codeLine = $"    Actions actions = new Actions(desktopSession.DesktopSessionElement);\n" +
+                            $"    actions.ContextClick(winElem_{elemName}).Build().Perform();\n";
 
             return GetCodeBlock(uiTask, elemName, codeLine);
         }


### PR DESCRIPTION
If right now someone is using the defaul UI Recorder that is in the Releases page, they will get lots of warning for every single DoubleClick or ContextClick function (Double-click and Right-click).

The warning looks the following:

`'RemoteWebDriver.Mouse' is obsolete: 'This property was never intended to be used in user code. Use the Actions or ActionBuilder class to send direct mouse input.'`

With Actions there is no warning and now we are not using Coordinates to perform these two actions, which should also produce less errors and misses for people who use UI Recorder Tool.