### PR TITLE
uiTreeNode.Top = top in GenerateXPath.cs

### DIFF
--- a/Tools/UIRecorder/UIRecorder/GenerateXPath.cs
+++ b/Tools/UIRecorder/UIRecorder/GenerateXPath.cs
@@ -473,7 +473,7 @@ namespace WinAppDriverUIRecorder
                 uiTreeNode.Name = Name;
                 uiTreeNode.AutomationId = AutomationId;
                 uiTreeNode.Left = left;
-                uiTreeNode.Top = left;
+                uiTreeNode.Top = top;
                 uiTreeNode.Width = width;
                 uiTreeNode.Height = height;
                 uiTreeNode.RuntimeId = runtimeId;


### PR DESCRIPTION
A fix for GenerateXPath.cs where uiTreeNode.Top was set to left instead of top